### PR TITLE
Feature/client/map display/location info popup

### DIFF
--- a/client/src/components/MapComponent.jsx
+++ b/client/src/components/MapComponent.jsx
@@ -1,4 +1,4 @@
-import React, { useState , useEffect} from 'react';
+import React, { useState, useEffect } from 'react';
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
@@ -71,9 +71,9 @@ const getIconByLocationType = (type) => {
 
 const MapComponent = ({ locations, nearbyLocations = [] }) => {
     const [filter, setFilter] = useState('all');  // State for filtering location types
-    const [showNearby, setShowNearby] = useState(false);  // State for showing nearby locations
+    const [showNearby, setShowNearby] = useState(true);  // Default to showing nearby locations
 
-    // Filter the locations based on the selected filter
+    // Determine the locations to show based on the showNearby state
     const locationsToShow = showNearby ? nearbyLocations : locations;
 
     // Filter the locations based on the selected filter (e.g., playground, beach, etc.)
@@ -100,7 +100,7 @@ const MapComponent = ({ locations, nearbyLocations = [] }) => {
                 </select>
 
                 {/* Checkbox to toggle between showing all or nearby locations */}
-                <label htmlFor="showNearby">
+                <label htmlFor="showNearby" style={{ marginLeft: '10px' }}>
                     <input
                         id="showNearby"
                         type="checkbox"
@@ -133,8 +133,7 @@ const MapComponent = ({ locations, nearbyLocations = [] }) => {
                             >
                                 <Popup>
                                     {/* Display information in the popup for each location */}
-                                    <strong>{location.Name}</strong> <br/>
-                                    <strong>{location.name}</strong> <br/>
+                                    <strong>{location.Name || 'Unnamed Location'}</strong> <br/>
                                     Type: {location.location_type} <br/>
                                 </Popup>
                             </Marker>

--- a/client/src/components/MapComponent.jsx
+++ b/client/src/components/MapComponent.jsx
@@ -131,10 +131,69 @@ const MapComponent = ({ locations, nearbyLocations = [] }) => {
                                 position={[lat, lon]} 
                                 icon={getIconByLocationType(location.location_type)}
                             >
-                                <Popup>
-                                    {/* Display information in the popup for each location */}
-                                    <strong>{location.Name || 'Unnamed Location'}</strong> <br/>
-                                    Type: {location.location_type} <br/>
+                               <Popup>
+                                    {/* Display different information based on the location_type */}
+                                    {location.location_type === 'beach' && (
+                                        <div>
+                                            <strong>{location.Name || 'Unnamed Beach'}</strong><br />
+                                            <strong>Location:</strong> {location.Location}<br />
+                                            <strong>Accessible:</strong> {location.Accessible}<br />
+                                            <strong>Barbecue Allowed:</strong> {location.Barbecue_Allowed}<br />
+                                            <strong>Concession Stand:</strong> {location.Concession_Stand}<br />
+                                            <strong>Description:</strong> <div dangerouslySetInnerHTML={{ __html: location.Description }}></div><br />
+                                            <strong>Directions:</strong> <div dangerouslySetInnerHTML={{ __html: location.Directions }}></div>
+                                        </div>
+                                    )}
+                                    {location.location_type === 'subway_stop' && (
+                                        <div>
+                                            <strong>{location.Name || 'Unnamed Subway Station'}</strong><br />
+                                            <strong>Location:</strong> {location.Location}<br />
+                                            <strong>ADA Status:</strong> {location.ADA_Status}<br />
+                                            <strong>Lines:</strong> {location.line}<br />
+                                            <strong>Accessible:</strong> {location.Accessible}<br />
+                                        </div>
+                                    )}
+                                    {location.location_type === 'restroom' && (
+                                        <div>
+                                            <strong>{location.facility_name || 'Unnamed Restroom'}</strong><br />
+                                            <strong>Location:</strong> {location.Location}<br />
+                                            <strong>Operator:</strong> {location.operator}<br />
+                                            <strong>Hours of Operation:</strong> {location.hours_of_operation}<br />
+                                            <strong>Status:</strong> {location.status}<br />
+                                            <strong>Accessible:</strong> {location.Accessible ? 'Yes' : 'No'}<br />
+                                        </div>
+                                    )}
+                                    {location.location_type === 'playground' && (
+                                        <div>
+                                            <strong>{location.Name || 'Unnamed Playground'}</strong><br />
+                                            <strong>Location:</strong> {location.Location}<br />
+                                            <strong>Accessible:</strong> {location.Accessible}<br />
+                                            <strong>Sensory-Friendly:</strong> {location['Sensory-Friendly'] === 'Y' ? 'Yes' : 'No'}<br />
+                                            <strong>ADA Accessible Comfort Station:</strong> {location.ADA_Accessible_Comfort_Station}<br />
+                                        </div>
+                                    )}
+                                    {location.location_type === 'pedestrian_signal' && (
+                                        <div>
+                                            <strong>{location.Location || 'Unnamed Pedestrian Signal'}</strong><br />
+                                            <strong>Borough:</strong> {location.borough}<br />
+                                            <strong>Installation Date:</strong> {new Date(location.date_insta).toLocaleDateString()}<br />
+                                            <strong>FEMA Flood Zone:</strong> {location.femafldt}<br />
+                                            <strong>Accessible:</strong> {location.Accessible}<br />
+                                        </div>
+                                    )}
+                                    {/* For unknown location types */}
+                                    {location.location_type !== 'beach' &&
+                                    location.location_type !== 'subway_stop' &&
+                                    location.location_type !== 'restroom' &&
+                                    location.location_type !== 'playground' &&
+                                    location.location_type !== 'pedestrian_signal' && (
+                                        <div>
+                                            <strong>{location.Name || 'Unnamed Location'}</strong><br />
+                                            <strong>Location:</strong> {location.Location}<br />
+                                            <strong>Type:</strong> {location.location_type}<br />
+                                            <strong>Accessible:</strong> {location.Accessible}<br />
+                                        </div>
+                                    )}
                                 </Popup>
                             </Marker>
                         );

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -4,12 +4,12 @@ import NavBar from '../components/NavBar.jsx';
 import MapComponent from '../components/MapComponent'; 
 import Toast from 'react-bootstrap/Toast';
 
-//homepage which is the main page the user lands on
+// Homepage which is the main page the user lands on
 function Home() {
     const [name, setName] = useState('');
     const [locations, setLocations] = useState([]);
     const [nearbyLocations, setNearbyLocations] = useState([]);
-    const [showNoLocation, setShowNoLocation] = useState(false); //State to show no location to render
+    const [showNoLocation, setShowNoLocation] = useState(false); // State to show no location to render
 
     useEffect(() => {
         const token = localStorage.getItem('token');
@@ -65,22 +65,33 @@ function Home() {
         }
     }, []);
 
-    useEffect(()=>{
+    useEffect(() => {
         if ((!locations || locations.length === 0) && (!nearbyLocations || nearbyLocations.length === 0)) {
             setShowNoLocation(true);
         } else {
             setShowNoLocation(false);
         }
-    }, [locations,nearbyLocations])
+    }, [locations, nearbyLocations]);
 
     return (
         <div>
             <NavBar />
             <h1>Welcome, {name}</h1>
-            
+
             {/* Pass locations and nearbyLocations to the MapComponent */}
-            <MapComponent locations={locations} nearbyLocations={nearbyLocations} />
-            <Toast onClose={() => setShowNoLocation(false)} show={showNoLocation} delay={3000} className="toast-bottom-right" bg='danger'>
+            <MapComponent 
+                locations={locations} 
+                nearbyLocations={nearbyLocations} 
+            />
+
+            <Toast 
+                onClose={() => setShowNoLocation(false)} 
+                show={showNoLocation} 
+                delay={3000} 
+                autohide 
+                className="toast-bottom-right" 
+                bg='danger'
+            >
                 <Toast.Header>
                     <strong className="me-auto">Alert</strong>
                 </Toast.Header>

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import '../style/Home.css';
 import NavBar from '../components/NavBar.jsx';
 import MapComponent from '../components/MapComponent'; 
@@ -10,8 +10,12 @@ function Home() {
     const [locations, setLocations] = useState([]);
     const [nearbyLocations, setNearbyLocations] = useState([]);
     const [showNoLocation, setShowNoLocation] = useState(false); // State to show no location to render
+    const effectRan = useRef(false);
 
     useEffect(() => {
+        if (effectRan.current) return;
+        effectRan.current = true;
+        
         const token = localStorage.getItem('token');
         if (token) {
             const decodedToken = JSON.parse(atob(token.split('.')[1]));


### PR DESCRIPTION
## Description
Set default to load nearby locations when the map is initialized and improved the information displayed in the popup based on the location type.


## What's in this change?
-Set the default state to show nearby locations when the map loads.
-Enhanced the popup content to display more detailed information depending on the location type (e.g., beach, subway, restroom).


## Testing changes
-Verified the changes locally on the frontend by viewing the map and checking the popups.
-Tested the deployment on Render to ensure the changes work in the production environment.
