### PR TITLE
marker cleanup & search fixes

### DIFF
--- a/client/src/components/SearchBar.jsx
+++ b/client/src/components/SearchBar.jsx
@@ -7,6 +7,7 @@ const SearchBar = ({ onSearch }) => {
 
     const handleSearch = async (event) => {
         setSearchTerm(event.target.value);
+        
         if (event.target.value) {
             try {
                 const response = await fetch(`${import.meta.env.VITE_PORT}/search?type=${event.target.value}`);
@@ -20,6 +21,7 @@ const SearchBar = ({ onSearch }) => {
             }
         } else {
             setSearchResults([]);
+            onSearch('');
         }
     };
 

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -23,16 +23,22 @@ function Home() {
     const [destination, setDestination] = useState({ lat: null, lon:  null});
     const [filterCriteria, setFilterCriteria] = useState({});
     const [showFilter, setShowFilter] = useState(false);
+    const [searchTerm, setSearchTerm] = useState('');
 
      // Toggle FilterSideBar visibility
     const handleFilterToggle = () => setShowFilter(!showFilter);
 
     // Update filter criteria from FilterSideBar
-    const handleFilterChange = (newCriteria) => setFilterCriteria(newCriteria);
-    
+    const handleFilterChange = (newCriteria) => {
+        setFilterCriteria(newCriteria);
+        setSelectedLocation('');
+        setSearchTerm('');
+    }
     //user selected locations
     const handleSearch = (searchTerm) => {
         setSelectedLocation(searchTerm);
+        setSearchTerm(searchTerm);
+        setFilterCriteria({});
     };
 
     useEffect(() => {
@@ -128,7 +134,7 @@ function Home() {
     return (
         <div>
             <NavBar />
-            <SearchBar onSearch={handleSearch} />
+            <SearchBar onSearch={handleSearch} searchTerm={searchTerm} />
             {/* Filter Button to open sidebar */}
             <Button variant="secondary"  className="filter-button" style={{ opacity: 0.5 }} onClick={handleFilterToggle}>Filter By</Button>
             


### PR DESCRIPTION
## Description
Marker popup clean up & search/filter fixes

## What's in this change?
Marker location description toggle for locations that have lengthy descriptions (beaches)
Mongodb json edits - Put Directions via google at the bottom

Fixed filter not working after search:
filter works when user deletes search field or does a new filter after search

Fixed search to not get filtered results when filter is on:
search resets filter on search

Doesn't push to the edge of the map anymore when clicking on filtered markers, but still does not center the marker 

## Testing changes
locally 