### PR TITLE
Feature/client server/search bar

### DIFF
--- a/client/src/components/MapComponent.jsx
+++ b/client/src/components/MapComponent.jsx
@@ -309,7 +309,7 @@ const MapCenterUpdater = ({ nearbyLocations,  searchLoc }) => {
         let slat = (searchLoc?.lat ?? searchLoc?.latitude  );
         let slon = (searchLoc?.lon ?? searchLoc?.longitude );
  
-        if (nearbyLocations.length > 0 && searcLoc == {}) {  //THIS MIGHT NOT WORK-- loads nearby and doesnt interfere with search centering
+        if (nearbyLocations.length > 0 && searchLoc == {}) {  
             map.setView(calculateCenter(nearbyLocations), map.getZoom());}
         else if (slat && slon){    
             map.setView([slat, slon], map.getZoom());
@@ -557,7 +557,7 @@ const MapComponent = ({ locations, nearbyLocations = [], selectedLocation , user
                                     {location.location_type === 'restroom' && (
                                         <div className={`info-container ${theme === 'dark' ? 'dark-mode' : ''}`}>
                                             <div>
-                                                <strong>{location.facility_name || 'Unnamed Restroom'}</strong><br />
+                                                <strong>{location.Name || 'Unnamed Restroom'}</strong><br />
                                                 <strong>Accessiblity Rating:</strong> {(Math.round(locationRating* 10) / 10) || '-'}<br />
                                                 <strong>Location:</strong> {location.Location}<br />
                                                 <strong>Operator:</strong> {location.operator}<br />
@@ -606,7 +606,7 @@ const MapComponent = ({ locations, nearbyLocations = [], selectedLocation , user
                                     {location.location_type === 'pedestrian_signal' && (
                                         <div className={`info-container ${theme === 'dark' ? 'dark-mode' : ''}`}>
                                             <div>
-                                                <strong>{location.Location || 'Unnamed Pedestrian Signal'}</strong><br />
+                                                <strong>{location.Name || 'Unnamed Pedestrian Signal'}</strong><br />
                                                 <strong>Accessiblity Rating:</strong> {(Math.round(locationRating* 10) / 10) || '-'}<br />
                                                 <strong>Borough:</strong> {location.borough}<br />
                                                 <strong>Installation Date:</strong> {new Date(location.date_insta).toLocaleDateString()}<br />

--- a/client/src/components/MapComponent.jsx
+++ b/client/src/components/MapComponent.jsx
@@ -295,6 +295,9 @@ const MapCenterUpdater = ({ nearbyLocations, selectedLocation, filterCriteria })
     useEffect(() => {
         let newCenter;
         let zoomLevel = map.getZoom();
+        // let slat = (searchLoc.lat || searchLoc.latitude);
+        // let slon = (searchLoc.lon || searchLoc.longitude);
+        // let sCenter = [slat, slon];
 
         //checks if a new filter is applied.
         const newfilter = Object.keys(filterCriteria).some(key => filterCriteria[key] && filterCriteria[key] !== prevFilter.current[key]);
@@ -311,12 +314,29 @@ const MapCenterUpdater = ({ nearbyLocations, selectedLocation, filterCriteria })
         if (newCenter || newfilter) {
             map.setView(newCenter || map.getCenter(), zoomLevel);
         }
-    }, [nearbyLocations, selectedLocation, filterCriteria, map]);
+        // else if (searchLoc && sCenter){
+        //     map.setView(sCenter, 15);
+        // }
+    }, [nearbyLocations, selectedLocation, filterCriteria, map]);   //  , searchLoc
 
     return null;
 };
+// const searchcenter = ({searchLoc}) => {
+//         const map = useMap();
+//         const slat = (searchLoc[0].lat || searchLoc[0].latitude);
+//         const slon = (searchLoc[0].lon || searchLoc[0].longitude);
+//         if (slat && slon){
+//         let sCenter = [slat, slon];
 
-const MapComponent = ({ locations, nearbyLocations = [], selectedLocation , userCoord, destination, filterCriteria}) => {
+//         if (sCenter) {
+//             map.setView(sCenter, 15);
+//         }
+//     }
+//     return null;
+//     };
+
+const MapComponent = ({ locations, nearbyLocations = [], selectedLocation , userCoord, destination, filterCriteria, searchLoc}) => {
+    //      , clearSearch
     const [showNearby, setShowNearby] = useState(true);  // Default to showing nearby location
     const [showToastError, setShowToastError] = useState(false);
     const [showToastSuccess, setShowToastSuccess] = useState(false);
@@ -383,6 +403,28 @@ const MapComponent = ({ locations, nearbyLocations = [], selectedLocation , user
         });
     };
 
+    useEffect(() => {
+        if (searchLoc) {
+            setShowNearby(false);
+           // searchCenter({searchLoc});
+        }
+    }, [searchLoc]);
+    
+    const handleNearbyToggle = () => {
+        setShowNearby(prevShowNearby => !prevShowNearby);
+        if (!showNearby) {
+            setSearchTerm('');
+            setSearchLoc('');
+            // clearSearch();
+        }
+        // else if (showNearby && (selectedLocation || searchLoc)){
+        //     setSearchLoc('');
+        //     setSearchTerm('');
+        //     clearSearch();
+        //     setShowNearby(false);
+        // }
+    };
+
     // DynamicMarker component to rescale the marker accordingly to the zoom of the map
     const DynamicMarker = ({ position, locationType, children }) => {
         const map = useMap();
@@ -446,8 +488,9 @@ const MapComponent = ({ locations, nearbyLocations = [], selectedLocation , user
                         type="checkbox"
                         // className={`${theme}`}
                         checked={showNearby}
-                        onChange={() => setShowNearby(!showNearby)}
+                        onChange={handleNearbyToggle}
                     />
+                    {/* onChange={() => setShowNearby(!showNearby)} */}
                     Show Nearby Locations Only
             </label>
             <MapContainer 

--- a/client/src/components/MapComponent.jsx
+++ b/client/src/components/MapComponent.jsx
@@ -288,36 +288,36 @@ const RoutingMachine = ({ start, routeTo, trafficSignals }) => {
 
 
 //zooms out only when a new filler is applied. Otherwise, keeps zoom level, even when a icon is clicked.
-const MapCenterUpdater = ({ nearbyLocations, selectedLocation, filterCriteria }) => {
+const MapCenterUpdater = ({ nearbyLocations, selectedLocation }) => {
     const map = useMap();
-    const prevFilter = useRef(filterCriteria);
 
     useEffect(() => {
         let newCenter;
-        let zoomLevel = map.getZoom();
         // let slat = (searchLoc.lat || searchLoc.latitude);
         // let slon = (searchLoc.lon || searchLoc.longitude);
         // let sCenter = [slat, slon];
 
         //checks if a new filter is applied.
-        const newfilter = Object.keys(filterCriteria).some(key => filterCriteria[key] && filterCriteria[key] !== prevFilter.current[key]);
+        // const newfilter = Object.keys(filterCriteria).some(key => filterCriteria[key] && filterCriteria[key] !== prevFilter.current[key]);
 
-        if (newfilter) {
-            zoomLevel = 12;
-            prevFilter.current = {...filterCriteria};//updates prevfilter.
-        } else if (selectedLocation && (selectedLocation.lat || selectedLocation.latitude) && (selectedLocation.lon || selectedLocation.longitude)) {
+        // if (newfilter) {
+        //     zoomLevel = 12;
+        //     prevFilter.current = {...filterCriteria};//updates prevfilter.
+        // }
+        if (selectedLocation && (selectedLocation.lat || selectedLocation.latitude) && (selectedLocation.lon || selectedLocation.longitude)) {
             newCenter = [selectedLocation.lat || selectedLocation.latitude, selectedLocation.lon || selectedLocation.longitude] ;
-        } else {
-            newCenter = calculateCenter(nearbyLocations);
         }
+        //  else {
+        //     newCenter = calculateCenter(nearbyLocations);
+        // }
 
-        if (newCenter || newfilter) {
-            map.setView(newCenter || map.getCenter(), zoomLevel);
+        if (newCenter) {
+            map.setView(newCenter, 17);
         }
         // else if (searchLoc && sCenter){
         //     map.setView(sCenter, 15);
         // }
-    }, [nearbyLocations, selectedLocation, filterCriteria, map]);   //  , searchLoc
+    }, [nearbyLocations, selectedLocation, map]);   //  , searchLoc
 
     return null;
 };
@@ -482,7 +482,7 @@ const MapComponent = ({ locations, nearbyLocations = [], selectedLocation , user
         <div>
             <ReviewSideBar show={showReview} handleClose={handleReviewToggle} location={recentlyOpened} rating={locationRating}/>
             {/* Checkbox to toggle between showing all or nearby locations */}
-            <label htmlFor="showNearby" style={{ marginLeft: '42%', marginTop: '5px' }} >
+            <label htmlFor="showNearby" style={{ marginLeft: '42%', marginTop: '5px', marginBottom: '0px' }} >
                     <input
                         id="showNearby"
                         type="checkbox"
@@ -506,7 +506,7 @@ const MapComponent = ({ locations, nearbyLocations = [], selectedLocation , user
                     attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
                 />
                 {/* This component will update the map center when nearbyLocations changes */}
-                <MapCenterUpdater nearbyLocations={nearbyLocations} selectedLocation={selectedLocation ? [selectedLocation] : filteredLocations} filterCriteria={filterCriteria} />
+                <MapCenterUpdater nearbyLocations={nearbyLocations} selectedLocation={selectedLocation ? [selectedLocation] : filteredLocations}/>
                 <RoutingMachine start={userCoord} routeTo={destination} trafficSignals={locations.filter(loc => loc.location_type === "pedestrian_signal")}/>
                 {/* Render Markers for filtered locations */}
                 {locationsToShow.map((location, index) => {
@@ -808,7 +808,7 @@ function DirectionModal(props) {
                         </div>
                     )}
                     <Button variant="outline-primary" className='addButton' style={{ borderRadius: '20px' }} onClick={() => setSearchTerm('Your Location')}>Your Location</Button>
-                    <Button variant="outline-success" className='addButton' style={{ borderRadius: '20px' }} type="submit">Find Route</Button>
+                    <Button variant="outline-success" className='addButton' style={{ borderRadius: '20px' }} type="submit">Accessible Walking Route</Button>
                 </Form>
             </Modal.Body>
             <Modal.Footer className={theme === 'dark' ? "d-flex-dark-mode" : "d-flex"}>

--- a/client/src/components/SearchBar.jsx
+++ b/client/src/components/SearchBar.jsx
@@ -51,8 +51,9 @@ const SearchBar = ({ onSearch }) => {
 
     return (
         <div className="search-bar">
-            <div className="greeting-message">Welcome, {name}</div>
-            <div className="search-message">Find the accessibilities around you</div>
+            {/* <div className="greeting-message">Welcome, {name}</div> */}
+            <div className="search-message">Explore an Accessible NYC
+            </div>
             <form className="d-flex" onSubmit={handleSearchSubmit}>
                 <input
                     className="form-control me-2"

--- a/client/src/components/SearchBar.jsx
+++ b/client/src/components/SearchBar.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect} from 'react';
 import '../style/Search.css';
 
-const SearchBar = ({ onSearch }) => {
+const SearchBar = ({ onSearch }) => {       
+    // , clearSearch
     const [searchTerm, setSearchTerm] = useState('');
     const [searchResults, setSearchResults] = useState([]);
     const [name, setName] = useState('');
+    const [searchLoc, setSearchLoc] = useState('')
 
     useEffect(() => {
         const token = localStorage.getItem('token');
@@ -43,6 +45,7 @@ const SearchBar = ({ onSearch }) => {
         setSearchTerm(location); //location rather name location.name; allows the search bar to be autofilled with the name of the location the user selects
         onSearch(location);
         setSearchResults([]);
+        setSearchLoc(location);
     };
 
 

--- a/client/src/components/SearchBar.jsx
+++ b/client/src/components/SearchBar.jsx
@@ -6,7 +6,7 @@ const SearchBar = ({ onSearch }) => {
     const [searchTerm, setSearchTerm] = useState('');
     const [searchResults, setSearchResults] = useState([]);
     const [name, setName] = useState('');
-    const [searchLoc, setSearchLoc] = useState('')
+    const [searchLoc, setSearchLoc] = useState({})
 
     useEffect(() => {
         const token = localStorage.getItem('token');
@@ -32,20 +32,20 @@ const SearchBar = ({ onSearch }) => {
             }
         } else {
             setSearchResults([]);
-            onSearch('');
+            onSearch('', {});
         }
     };
 
     const handleSearchSubmit = (event) => {
         event.preventDefault();
-        onSearch(searchTerm);
+        onSearch(searchTerm, searchLoc);
     };
 
-    const handleLocationSelection = (location) => {
-        setSearchTerm(location); //location rather name location.name; allows the search bar to be autofilled with the name of the location the user selects
-        onSearch(location);
+    const handleLocationSelection = (result) => {
+        setSearchTerm(result.Name); //location rather name location.name; allows the search bar to be autofilled with the name of the location the user selects
+        onSearch(result.Name, result);
         setSearchResults([]);
-        setSearchLoc(location);
+        setSearchLoc(result);
     };
 
 
@@ -58,7 +58,7 @@ const SearchBar = ({ onSearch }) => {
                 <input
                     className="form-control me-2"
                     type="search"
-                    placeholder="Search"
+                    placeholder="Search places . . ."
                     aria-label="Search"
                     value={searchTerm}
                     onChange={handleSearch}
@@ -71,7 +71,7 @@ const SearchBar = ({ onSearch }) => {
             {searchResults.length > 0 && (
                 <div className="dropdown-menu show position-absolute">
                     {searchResults.map((result, index) => (
-                        <button key={index} className="dropdown-item" onClick={() => handleLocationSelection(result.Name)}>
+                        <button key={index} className="dropdown-item" onClick={() => handleLocationSelection(result)}>
                             {result.Name}
                         </button>
                     ))}

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -25,22 +25,21 @@ function Home() {
     const [filterCriteria, setFilterCriteria] = useState({});
     const [showFilter, setShowFilter] = useState(false);
     const [searchTerm, setSearchTerm] = useState('');
-    const [searchLoc, setSearchLoc] = useState('');
-    //const [nearbyTemp, setNearbyTemp] = useState([]);
+    const [searchLoc, setSearchLoc] = useState({});
 
     const handleFilterToggle = () => setShowFilter(!showFilter);
     const handleFilterChange = (newCriteria) => {
         setFilterCriteria(newCriteria);
         setSelectedLocation('');
         setSearchTerm('');
+        setSearchLoc({});
     };
 
-    const handleSearch = (searchTerm) => {
+    const handleSearch = (searchTerm, location) => {
         setSelectedLocation(searchTerm);
         setSearchTerm(searchTerm);
         setFilterCriteria({});
-        setSearchLoc(searchTerm);
-        //setNearbyTemp(nearbyLocations)
+        setSearchLoc(location);
     };
 
     const handleAcceptCookies = () => {
@@ -204,7 +203,10 @@ function Home() {
     return (
         <div>
             <NavBar />
-            <SearchBar onSearch={handleSearch} searchTerm={searchTerm} searchLoc ={searchLoc} />
+            <SearchBar 
+                onSearch={handleSearch} 
+                searchTerm={searchTerm} 
+                searchLoc ={searchLoc} />
                 {/* clearSearch={clearSearch} */}
             <Button variant="secondary" className="filter-button" onClick={handleFilterToggle}>
                 Filter By

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -25,6 +25,8 @@ function Home() {
     const [filterCriteria, setFilterCriteria] = useState({});
     const [showFilter, setShowFilter] = useState(false);
     const [searchTerm, setSearchTerm] = useState('');
+    const [searchLoc, setSearchLoc] = useState('');
+    //const [nearbyTemp, setNearbyTemp] = useState([]);
 
     const handleFilterToggle = () => setShowFilter(!showFilter);
     const handleFilterChange = (newCriteria) => {
@@ -37,6 +39,8 @@ function Home() {
         setSelectedLocation(searchTerm);
         setSearchTerm(searchTerm);
         setFilterCriteria({});
+        setSearchLoc(searchTerm);
+        //setNearbyTemp(nearbyLocations)
     };
 
     const handleAcceptCookies = () => {
@@ -200,7 +204,8 @@ function Home() {
     return (
         <div>
             <NavBar />
-            <SearchBar onSearch={handleSearch} searchTerm={searchTerm} />
+            <SearchBar onSearch={handleSearch} searchTerm={searchTerm} searchLoc ={searchLoc} />
+                {/* clearSearch={clearSearch} */}
             <Button variant="secondary" className="filter-button" onClick={handleFilterToggle}>
                 Filter By
             </Button>
@@ -214,6 +219,8 @@ function Home() {
                 userCoord={startCoord}
                 destination={destination}
                 filterCriteria={filterCriteria}
+                searchLoc={searchLoc}
+                ///* clearSearch={clearSearch} */
             />
             <Toast onClose={() => setShowCookieNotification(false)} show={showCookieNotification} delay={3000} autohide className="toast-bottom-right" bg="info">
                 <Toast.Header>

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -256,7 +256,7 @@ function Profile() {
                         <ListGroup className="scrollable-list">
                             {favoriteLocations.map((location, index) => (
                                 <ListGroup.Item key={index} className={`d-flex justify-content-between align-items-center ${theme}`}>
-                                    {location.facility_name || location.Name || location.ntaname || 'No Name'}
+                                    {location.Name || 'No Name'}
                                     <div>
                                         <Button variant="outline-success" onClick={() => handleShow(location.Name)}>Show</Button>
                                         <Button variant="outline-success" className='marginbutton' onClick={() => handlePathTo(location)}>Path to</Button>
@@ -275,7 +275,7 @@ function Profile() {
                                 {suggestLocations.length>0?(
                                     suggestLocations.map((location,index)=>(
                                         <ListGroup.Item key={index} className={`d-flex justify-content-between align-items-center ${theme}`}>
-                                            {location.facility_name||location.Name||'No Name'}
+                                            {location.Name|| 'No Name'}
                                             <div className="d-flex gap-2"> 
                                                 <Button variant="outline-success" onClick={() => handleShow(location.Name)}>Show</Button>
                                                 <Button variant="outline-success" className='marginbutton' onClick={() => handlePathTo(location)}>Path to</Button>

--- a/client/src/style/Search.css
+++ b/client/src/style/Search.css
@@ -5,15 +5,17 @@
     text-align: center;
 }
 
-.greeting-message {
+/* .greeting-message {
   font-weight: bold;
   font-size: 1.5em;
-  margin-top: 0.5em;
-}
+  margin-top: 0.1em;
+} */
 
 .search-message{
-  font-size: 1em;
-  margin-bottom: 1em;
+  font-weight: bold;
+  font-size: 1.5em;
+  /* margin-bottom: 0.1em; */
+  margin: 0;
 }
 
 /*button*/

--- a/server/models/location.model.js
+++ b/server/models/location.model.js
@@ -1,6 +1,6 @@
 import mongoose from 'mongoose';
 
-// Define the schema for the 'all_locations' collection in MongoDB
+// Define the schema for the 'all_locations' collection in MongoDB  //final_locations
 const locationSchema = new mongoose.Schema({
     location_type: { 
         type: String 
@@ -25,5 +25,5 @@ const locationSchema = new mongoose.Schema({
 });
 
 const Location = mongoose.model('all_locations', locationSchema);
-
+//change to final_locations
 export default Location;

--- a/server/routes/location.route.js
+++ b/server/routes/location.route.js
@@ -43,7 +43,7 @@ router.get('/locations', async (req, res) => {
 
 // Route to fetch locations near the user's coordinates
 router.get('/locations/nearby', async (req, res) => {
-    const { lat, lon, distance = 2000 } = req.query; // Default set to 2000 meters
+    const { lat, lon, distance = 3000 } = req.query; // Default set to 2000 meters
 
     // Validate that lat and lon are provided
     if (!lat || !lon) {


### PR DESCRIPTION
## Description
Fixed search centering, nearby toggles off on search
NEED TO CHECK nearby locations are centered on first page load & if it causes conflicts with search centering

## What's in this change?
Search Centering added
Nearby toggles off on search
Removed default NYC map centering on filter change
Removed original nearby centering 
(one of these caused zoomed in marker click to push map to edge)
Removed DynamicMarker

ETC
Home page message change
'Find Route' button in Directions-> 'Accessible Walking Route'

**Things that might cause conflict somewhere:**
Changed how nearbytoggle works  -line 398, 456
Search passes location.name & location object itself - Searchbar.jsx onSearch
Searchresults passes location object instead of name -Searchbar.jsx - line 74


## Testing changes
Need to test if nearby centers when toggled
checked nearby toggling, search, routing, profile-show,profile-path

profile-show,profile-path needs update so that it centers
marker centering still needs fix
