### PR TITLE
Smaller Icons, map optimization again

### DIFF
--- a/client/src/components/MapComponent.jsx
+++ b/client/src/components/MapComponent.jsx
@@ -15,11 +15,11 @@ import '../style/MapComponent.css';
 import ReviewSideBar from './ReviewSideBar';
 
 // Def custom icons for each location type
-const beachIconUrl = '/assets/beach-100.png';
-const playgroundIconUrl = '/assets/playground-100.png';
-const signalIconUrl = '/assets/traffic-light-100.png';
-const subwayIconUrl = '/assets/subway-100.png';
-const restroomIconUrl = '/assets/restroom-100.png';
+const beachIconUrl =        '/assets/50px/beach-100.png';
+const playgroundIconUrl =   '/assets/50px/playground-100.png';
+const signalIconUrl =       '/assets/50px/traffic-light-100.png';
+const subwayIconUrl =       '/assets/50px/subway-100.png';
+const restroomIconUrl =      '/assets/50px/restroom-100.png';
 
 // Bounds for the map to stay within NYC
 const nycBounds = [
@@ -346,16 +346,16 @@ const MapCenterUpdater = ({ nearbyLocations,  searchLoc, showNearby, setMarkerLo
         let slon = (searchLoc?.lon ?? searchLoc?.longitude );
 
         if (markerLoc){
-            map.setView(markerLoc, map.getZoom());
-            setTimeout(() => setMarkerLoc(null), 300); 
+            map.setView(markerLoc, map.getZoom(), { animate: false });
+            setMarkerLoc(null);
             return
         }
         else if (showNearby==true && nearbyLocations.length > 0  && Object.keys(searchLoc).length === 0 && (map.getZoom()<14) && !markerLoc  ) {  
-            map.setView(calculateCenter(nearbyLocations), map.getZoom());
+            map.setView(calculateCenter(nearbyLocations), map.getZoom(), { animate: false });
             return
         }
         else if (slat && slon){    
-            map.setView([slat, slon], map.getZoom());
+            map.setView([slat, slon], map.getZoom(), { animate: false });
             return
         }
      
@@ -493,7 +493,7 @@ const MapComponent = ({ locations, nearbyLocations = [], selectedLocation , user
                         // className={`${theme}`}
                         checked={showNearby}
                         onChange={handleNearbyToggle}
-                    />
+                        />
                     {/* onChange={() => setShowNearby(!showNearby)} */}
                     Show Nearby Locations Only
             </label>

--- a/client/src/components/MapComponent.jsx
+++ b/client/src/components/MapComponent.jsx
@@ -107,7 +107,7 @@ const calculateCenter = (nearbyLocations) => {
     ];
 };
 
-const RoutingMachine = ({ start, routeTo, trafficSignals }) => {
+const RoutingMachine = React.memo(({ start, routeTo, trafficSignals }) => {
     const map = useMap();
     const routingLayerRef = useRef(null); 
     const closeControlRef = useRef(null); 
@@ -316,10 +316,10 @@ const RoutingMachine = ({ start, routeTo, trafficSignals }) => {
     }, [map, start, routeTo, trafficSignals]);
 
     return null;
-};
+});
 
 //zooms out only when a new filler is applied. Otherwise, keeps zoom level, even when a icon is clicked.
-const MapCenterUpdater = ({ nearbyLocations,  searchLoc, showNearby, setMarkerLoc, markerLoc}) => { 
+const MapCenterUpdater = React.memo(({ nearbyLocations,  searchLoc, showNearby, setMarkerLoc, markerLoc}) => { 
     const map = useMap();
     
     useEffect(() => {
@@ -363,11 +363,11 @@ const MapCenterUpdater = ({ nearbyLocations,  searchLoc, showNearby, setMarkerLo
     }, [ nearbyLocations, showNearby, searchLoc, markerLoc, setMarkerLoc, map]);   
 
     return null;
-};
+});
 
 
 
-const MapComponent = ({ locations, nearbyLocations = [], selectedLocation , userCoord, destination, filterCriteria, searchLoc}) => {
+const MapComponent = React.memo(({ locations, nearbyLocations = [], selectedLocation , userCoord, destination, filterCriteria, searchLoc}) => {
     const [showNearby, setShowNearby] = useState(true);  // Default to showing nearby location
     const [showToastError, setShowToastError] = useState(false);
     const [showToastSuccess, setShowToastSuccess] = useState(false);
@@ -726,7 +726,7 @@ const MapComponent = ({ locations, nearbyLocations = [], selectedLocation , user
             />
         </div>
     );
-};
+});
 
 function DirectionModal(props) {
     const [showToastError, setShowToastError] = useState(false);


### PR DESCRIPTION
 ## Description
--RESTORING TO OLD PR--cause PR got overwritten 
Marker Centering
Set icon resolution to 50x50 and compressed them
Added React.memo for RoutingMachine, MapCenterUpdater, Mapcomponent so it stops re-rendering map. 
Overall I think it's a little faster. 
Commented out 'No Locations to load' toast msg that pops up on first home page load

## What's in this change?
icon resizing & compression - public/assets/50px
react.memo - mapcomponent: RoutingMachine, MapCenterUpdater, Mapcomponent

## Testing changes
local
Not sure if react.memo will break sth, tested most stuff and they're fine: filter, search, centering, review, addreview, directions